### PR TITLE
feat(auth): add YouTube data capture with dual ID extraction and debu…

### DIFF
--- a/lib/features/auth_credentials/screens/auth_credentials_forgot_pass_screen.dart
+++ b/lib/features/auth_credentials/screens/auth_credentials_forgot_pass_screen.dart
@@ -45,6 +45,7 @@ class _AuthCredentialsForgotPassScreenState extends State<AuthCredentialsForgotP
   Widget build(BuildContext context) {
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
+        transitionBetweenRoutes: false,
         middle: Text(
           "Forgot Password - Plus",
           style: GoogleFonts.lato(fontWeight: FontWeight.bold),

--- a/lib/features/auth_credentials/screens/auth_credentials_register_screen.dart
+++ b/lib/features/auth_credentials/screens/auth_credentials_register_screen.dart
@@ -15,6 +15,7 @@ class _AuthCredentialsRegisterScreenState extends State<AuthCredentialsRegisterS
   Widget build(BuildContext context) {
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
+        transitionBetweenRoutes: false,
         middle: Text(
           "Sign up - Plus",
           style: GoogleFonts.lato(fontWeight: FontWeight.bold),

--- a/lib/features/auth_google/auth_google_model.dart
+++ b/lib/features/auth_google/auth_google_model.dart
@@ -7,6 +7,12 @@ class AuthGoogleUserData {
   final String? accessToken; // Token OAuth Google
   final String? idToken; // ID Token JWT do Google
   final List<String> scopes; // Escopos autorizados
+  
+  // YouTube Data
+  final String? youtubeUserId; // YouTube User ID (sem prefixo UC, ex: AW0lk_gWgAjclw3EXT_hmg)
+  final String? youtubeChannelId; // YouTube Channel ID (com prefixo UC, ex: UCAW0lk_gWgAjclw3EXT_hmg)
+  final String? youtubeChannelTitle; // Nome do canal YouTube
+  final bool hasYouTubeChannel; // Se possui canal YouTube
 
   const AuthGoogleUserData({
     required this.id,
@@ -16,6 +22,10 @@ class AuthGoogleUserData {
     this.accessToken,
     this.idToken,
     this.scopes = const [],
+    this.youtubeUserId,
+    this.youtubeChannelId,
+    this.youtubeChannelTitle,
+    this.hasYouTubeChannel = false,
   });
 
   /// Extrai primeiro nome do displayName
@@ -34,7 +44,7 @@ class AuthGoogleUserData {
   }
 
   @override
-  String toString() => 'AuthGoogleUserData(id: $id, email: $email, name: $displayName)';
+  String toString() => 'AuthGoogleUserData(id: $id, email: $email, name: $displayName, youtubeUserId: $youtubeUserId, youtubeChannelId: $youtubeChannelId)';
 }
 
 /// Request para enviar dados OAuth do Google ao backend
@@ -46,6 +56,9 @@ class AuthGoogleOAuthRequest {
   final String oauthId; // Google User ID
   final String accessToken; // Token OAuth do Google
   final String? idToken; // ID Token JWT
+  final String? youtubeUserId; // YouTube User ID (sem UC)
+  final String? youtubeChannelId; // YouTube Channel ID (com UC)
+  final String? youtubeChannelTitle; // Título do canal YouTube
 
   const AuthGoogleOAuthRequest({
     required this.email,
@@ -55,6 +68,9 @@ class AuthGoogleOAuthRequest {
     required this.oauthId,
     required this.accessToken,
     this.idToken,
+    this.youtubeUserId,
+    this.youtubeChannelId,
+    this.youtubeChannelTitle,
   });
 
   Map<String, dynamic> toJson() {
@@ -71,6 +87,16 @@ class AuthGoogleOAuthRequest {
     }
     if (idToken != null && idToken!.isNotEmpty) {
       json['idToken'] = idToken;
+    }
+    // ✅ Adicionar dados YouTube ao backend
+    if (youtubeUserId != null && youtubeUserId!.isNotEmpty) {
+      json['youtubeUserId'] = youtubeUserId;
+    }
+    if (youtubeChannelId != null && youtubeChannelId!.isNotEmpty) {
+      json['youtubeChannelId'] = youtubeChannelId;
+    }
+    if (youtubeChannelTitle != null && youtubeChannelTitle!.isNotEmpty) {
+      json['youtubeChannelTitle'] = youtubeChannelTitle;
     }
 
     return json;

--- a/lib/features/auth_google/auth_google_service.dart
+++ b/lib/features/auth_google/auth_google_service.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:http/http.dart' as http;
 import 'package:portugal_guide/app/helpers/env_key_helper_config.dart';
+import 'package:portugal_guide/util/oauth_debug_logger.dart';
 import 'package:portugal_guide/features/auth_credentials/auth_credentials_model.dart';
 import 'package:portugal_guide/features/auth_credentials/auth_credentials_service.dart';
 import 'package:portugal_guide/features/auth_google/auth_google_model.dart';
@@ -102,8 +103,65 @@ class AuthGoogleService {
         print('🔑 [AuthGoogleService] ID Token obtido: ${auth.idToken?.substring(0, 20) ?? 'null'}...');
       }
 
-      // 5. Retornar dados do usuário
-      return AuthGoogleUserData(
+      // 5. Buscar informações do YouTube (incluindo User ID + Channel ID)
+      String? youtubeUserId; // User ID sem prefixo UC
+      String? youtubeChannelId; // Channel ID com prefixo UC
+      String? youtubeChannelTitle;
+      bool hasYouTubeChannel = false;
+      
+      if (auth.accessToken != null) {
+        try {
+          // NOVA IMPLEMENTAÇÃO: Tentar múltiplos métodos para obter YouTube User ID
+          if (kDebugMode) {
+            print('📺 [AuthGoogleService] === INICIANDO BUSCA DE YOUTUBE USER ID ===');
+          }
+          
+          // Método 1: Analisar ID Token (pode conter User ID)
+          if (auth.idToken != null) {
+            await _tryExtractUserIdFromIdToken(auth.idToken!);
+          }
+          
+          // Método 2: Tentar endpoint de canal (retorna User ID + Channel ID se existir)
+          final youtubeInfo = await _fetchYouTubeChannelInfo(auth.accessToken!);
+          youtubeUserId = youtubeInfo['userId']; // User ID sem "UC"
+          youtubeChannelId = youtubeInfo['channelId']; // Channel ID com "UC"
+          youtubeChannelTitle = youtubeInfo['title'];
+          hasYouTubeChannel = youtubeChannelId != null;
+          
+          // Método 3: Tentar obter informações básicas do YouTube (User ID básico)
+          if (youtubeUserId == null) {
+            final basicInfo = await _fetchYouTubeBasicUserInfo(auth.accessToken!);
+            if (basicInfo['userId'] != null) {
+              youtubeUserId = basicInfo['userId'];
+              if (kDebugMode) {
+                print('✅ [AuthGoogleService] YouTube Basic User ID encontrado: $youtubeUserId');
+              }
+            }
+          }
+          
+          if (kDebugMode) {
+            if (hasYouTubeChannel) {
+              print('✅ [AuthGoogleService] YouTube Channel encontrado:');
+              print('   - User ID: $youtubeUserId (sem prefixo UC)');
+              print('   - Channel ID: $youtubeChannelId (com prefixo UC)');
+              print('   - Channel Title: $youtubeChannelTitle');
+            } else if (youtubeUserId != null) {
+              print('✅ [AuthGoogleService] YouTube User ID básico encontrado: $youtubeUserId');
+            } else {
+              print('⚠️ [AuthGoogleService] Nenhum YouTube ID capturado');
+            }
+            print('📺 [AuthGoogleService] === FIM DA BUSCA ===');
+          }
+        } catch (e) {
+          if (kDebugMode) {
+            print('⚠️ [AuthGoogleService] Erro ao buscar YouTube info (não-crítico): $e');
+          }
+          // Não quebra o fluxo de login se falhar
+        }
+      }
+
+      // 6. Retornar dados do usuário (incluindo YouTube)
+      final userData = AuthGoogleUserData(
         id: account.id,
         email: account.email,
         displayName: account.displayName,
@@ -111,11 +169,26 @@ class AuthGoogleService {
         accessToken: auth.accessToken,
         idToken: auth.idToken,
         scopes: [], // grantedScopes não disponível nesta versão
+        youtubeUserId: youtubeUserId,
+        youtubeChannelId: youtubeChannelId,
+        youtubeChannelTitle: youtubeChannelTitle,
+        hasYouTubeChannel: hasYouTubeChannel,
       );
+
+      // ℹ️ Dados do Google capturados (backend receberá depois)
+      // Logger será chamado APÓS autenticação com backend para salvar tudo junto
+
+      return userData;
     } catch (e) {
       if (kDebugMode) {
         print('❌ [AuthGoogleService] Erro ao fazer login com Google: $e');
       }
+
+      // 🐛 DEBUG: Salvar erro em arquivo .log
+      await OAuthDebugLogger.logOAuthData(
+        googleData: {'error_stage': 'google_sign_in'},
+        errorMessage: e.toString(),
+      );
 
       if (e is GoogleOAuthException) {
         rethrow;
@@ -123,6 +196,245 @@ class AuthGoogleService {
 
       throw GoogleOAuthException('Erro ao autenticar com Google: $e');
     }
+  }
+
+  /// Busca informações do canal YouTube do usuário
+  /// 
+  /// Retorna um Map com:
+  /// - 'userId': YouTube User ID sem prefixo UC (ex: AW0lk_gWgAjclw3EXT_hmg, null se não tem canal)
+  /// - 'channelId': YouTube Channel ID com prefixo UC (ex: UCAW0lk_gWgAjclw3EXT_hmg, null se não tem canal)
+  /// - 'title': Nome do canal (null se não tem canal)
+  /// 
+  /// Usa YouTube Data API v3: channels?mine=true
+  Future<Map<String, String?>> _fetchYouTubeChannelInfo(String accessToken) async {
+    try {
+      if (kDebugMode) {
+        print('📺 [AuthGoogleService] Buscando informações do YouTube...');
+      }
+
+      final response = await _httpClient.get(
+        Uri.parse(
+          'https://www.googleapis.com/youtube/v3/channels'
+          '?part=id,snippet'
+          '&mine=true',
+        ),
+        headers: {
+          'Authorization': 'Bearer $accessToken',
+          'Accept': 'application/json',
+        },
+      );
+
+      if (kDebugMode) {
+        print('📺 [AuthGoogleService] YouTube API Status: ${response.statusCode}');
+      }
+
+      if (response.statusCode == 200) {
+        final Map<String, dynamic> jsonResponse = jsonDecode(response.body);
+        
+        // 🐛 DEBUG: Mostrar resposta completa
+        if (kDebugMode) {
+          print('📺 [AuthGoogleService] YouTube API Response: ${jsonEncode(jsonResponse)}');
+        }
+        
+        final List<dynamic> items = jsonResponse['items'] ?? [];
+
+        if (items.isEmpty) {
+          // Usuário não tem canal YouTube
+          if (kDebugMode) {
+            print('📺 [AuthGoogleService] API retornou items vazio - usuário não possui canal YouTube criado');
+            print('📺 [AuthGoogleService] Nota: Ter conta Google ≠ ter canal YouTube');
+            print('📺 [AuthGoogleService] Para criar canal: https://www.youtube.com/create_channel');
+          }
+          return {'userId': null, 'channelId': null, 'title': null};
+        }
+
+        // Pega o primeiro canal (geralmente usuário tem apenas um)
+        final channel = items[0];
+        final channelId = channel['id'] as String?;
+        final channelTitle = channel['snippet']?['title'] as String?;
+        
+        // ✅ Extrair User ID removendo prefixo "UC" do Channel ID
+        String? userId;
+        if (channelId != null && channelId.startsWith('UC') && channelId.length > 2) {
+          userId = channelId.substring(2); // Remove "UC" prefix
+        }
+        
+        if (kDebugMode) {
+          print('📺 [AuthGoogleService] Channel ID encontrado: $channelId');
+          print('📺 [AuthGoogleService] User ID extraído: $userId (sem prefixo UC)');
+          print('📺 [AuthGoogleService] Channel Title: $channelTitle');
+        }
+
+        return {
+          'userId': userId,
+          'channelId': channelId,
+          'title': channelTitle,
+        };
+      } else if (response.statusCode == 403) {
+        // Quota exceeded ou API não habilitada
+        if (kDebugMode) {
+          print('⚠️ [AuthGoogleService] YouTube API 403: Quota excedida ou API não habilitada');
+        }
+        return {'userId': null, 'channelId': null, 'title': null};
+      } else {
+        throw Exception('YouTube API falhou com status ${response.statusCode}');
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print('❌ [AuthGoogleService] Erro ao buscar YouTube info: $e');
+      }
+      return {'userId': null, 'channelId': null, 'title': null};
+    }
+  }
+
+  /// [NOVO] Tenta extrair YouTube User ID do ID Token (JWT)
+  /// 
+  /// O ID Token pode conter informações adicionais no payload.
+  /// Nota: User ID legado (UXeX...) pode não estar disponível.
+  Future<void> _tryExtractUserIdFromIdToken(String idToken) async {
+    try {
+      if (kDebugMode) {
+        print('🔐 [AuthGoogleService] Método 1: Analisando ID Token...');
+      }
+      
+      // JWT tem 3 partes: header.payload.signature
+      final parts = idToken.split('.');
+      if (parts.length != 3) {
+        if (kDebugMode) {
+          print('⚠️ [AuthGoogleService] ID Token inválido (não tem 3 partes)');
+        }
+        return;
+      }
+      
+      // Decodificar payload (Base64URL)
+      String payload = parts[1];
+      // Adicionar padding se necessário
+      while (payload.length % 4 != 0) {
+        payload += '=';
+      }
+      
+      // Base64URL decode
+      final normalizedPayload = payload.replaceAll('-', '+').replaceAll('_', '/');
+      final decodedBytes = base64Decode(normalizedPayload);
+      final decodedPayload = utf8.decode(decodedBytes);
+      final Map<String, dynamic> payloadJson = jsonDecode(decodedPayload);
+      
+      if (kDebugMode) {
+        print('🔐 [AuthGoogleService] ID Token payload completo:');
+        print(jsonEncode(payloadJson));
+        
+        // Verificar campos específicos que podem conter User ID
+        final possibleUserIdFields = ['sub', 'user_id', 'youtube_user_id', 'yt_user_id'];
+        for (final field in possibleUserIdFields) {
+          if (payloadJson.containsKey(field)) {
+            print('🔍 [AuthGoogleService] Campo "$field": ${payloadJson[field]}');
+          }
+        }
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print('⚠️ [AuthGoogleService] Erro ao analisar ID Token: $e');
+      }
+    }
+  }
+
+  /// [NOVO] Tenta obter YouTube User ID básico usando métodos alternativos
+  /// 
+  /// Tenta múltiplos endpoints da YouTube API para capturar User ID legado
+  /// Retorna Map com 'userId' se encontrado, ou null
+  Future<Map<String, String?>> _fetchYouTubeBasicUserInfo(String accessToken) async {
+    if (kDebugMode) {
+      print('🔍 [AuthGoogleService] Método 3: Tentando obter YouTube Basic User ID...');
+    }
+    
+    // Lista de endpoints alternativos para tentar
+    final endpoints = [
+      // Endpoint 1: Informações do usuário YouTube (pode incluir User ID)
+      'https://www.googleapis.com/youtube/v3/channels?mine=true&part=id,snippet,contentDetails,statistics',
+      
+      // Endpoint 2: Tentar obter info de canais favoritos (fallback)
+      'https://www.googleapis.com/youtube/v3/subscriptions?mine=true&part=snippet&maxResults=1',
+      
+      // Endpoint 3: Activities (histórico do usuário pode conter User ID)
+      'https://www.googleapis.com/youtube/v3/activities?mine=true&part=snippet,contentDetails&maxResults=1',
+    ];
+    
+    for (int i = 0; i < endpoints.length; i++) {
+      try {
+        if (kDebugMode) {
+          print('🔍 [AuthGoogleService] Tentando endpoint ${i + 1}/${endpoints.length}...');
+        }
+        
+        final response = await _httpClient.get(
+          Uri.parse(endpoints[i]),
+          headers: {
+            'Authorization': 'Bearer $accessToken',
+            'Accept': 'application/json',
+          },
+        );
+        
+        if (kDebugMode) {
+          print('📡 [AuthGoogleService] Endpoint ${i + 1} - Status: ${response.statusCode}');
+        }
+        
+        if (response.statusCode == 200) {
+          final Map<String, dynamic> jsonResponse = jsonDecode(response.body);
+          
+          if (kDebugMode) {
+            print('📡 [AuthGoogleService] Endpoint ${i + 1} - Response completa:');
+            print(jsonEncode(jsonResponse));
+          }
+          
+          // Tentar extrair User ID de diferentes campos
+          final possibleUserIdPaths = [
+            ['items', 0, 'id'],
+            ['items', 0, 'snippet', 'userId'],
+            ['items', 0, 'snippet', 'channelId'],
+            ['items', 0, 'contentDetails', 'userId'],
+            ['userId'],
+            ['channelId'],
+          ];
+          
+          for (final path in possibleUserIdPaths) {
+            dynamic current = jsonResponse;
+            bool found = true;
+            
+            for (final key in path) {
+              if (current is Map && current.containsKey(key)) {
+                current = current[key];
+              } else if (current is List && key is int && key < current.length) {
+                current = current[key];
+              } else {
+                found = false;
+                break;
+              }
+            }
+            
+            if (found && current is String && current.isNotEmpty) {
+              if (kDebugMode) {
+                print('✅ [AuthGoogleService] Possível User ID encontrado em ${path.join('.')}: $current');
+              }
+              
+              // Se começa com UX (User ID legado) ou UC (Channel ID), pode ser útil
+              if (current.startsWith('UX') || current.startsWith('UC')) {
+                return {'userId': current};
+              }
+            }
+          }
+        }
+      } catch (e) {
+        if (kDebugMode) {
+          print('⚠️ [AuthGoogleService] Erro no endpoint ${i + 1}: $e');
+        }
+        continue; // Tenta próximo endpoint
+      }
+    }
+    
+    if (kDebugMode) {
+      print('⚠️ [AuthGoogleService] Nenhum User ID básico encontrado após ${endpoints.length} tentativas');
+    }
+    
+    return {'userId': null};
   }
 
   /// Envia dados OAuth para backend e obtém JWT do app
@@ -138,6 +450,10 @@ class AuthGoogleService {
         oauthId: googleData.id,
         accessToken: googleData.accessToken!,
         idToken: googleData.idToken,
+        // ✅ Enviar YouTube User ID e Channel ID para backend
+        youtubeUserId: googleData.youtubeUserId,
+        youtubeChannelId: googleData.youtubeChannelId,
+        youtubeChannelTitle: googleData.youtubeChannelTitle,
       );
 
       if (kDebugMode) {
@@ -170,6 +486,32 @@ class AuthGoogleService {
         if (kDebugMode) {
           print('✅ [AuthGoogleService] Autenticação com backend bem-sucedida');
           print('🔑 [AuthGoogleService] App Token: ${loginResponse.token.substring(0, 20)}...');
+        }
+
+        // 🐛 DEBUG: Salvar resposta do backend em arquivo .log (COMPLETO com YouTube)
+        await OAuthDebugLogger.logOAuthData(
+          googleData: {
+            'id': googleData.id,
+            'email': googleData.email,
+            'displayName': googleData.displayName,
+            'photoUrl': googleData.photoUrl,
+            'accessToken': googleData.accessToken,
+            'idToken': googleData.idToken,
+            'scopes': googleData.scopes,
+            // ✨ Dados YouTube
+            'youtubeUserId': googleData.youtubeUserId,
+            'youtubeChannelId': googleData.youtubeChannelId,
+            'youtubeChannelTitle': googleData.youtubeChannelTitle,
+            'hasYouTubeChannel': googleData.hasYouTubeChannel,
+            // Dados enviados ao backend
+            'sentToBackend': request.toJson(),
+          },
+          backendResponse: jsonResponse,
+        );
+
+        // 🖨️ ANDROID FIX: Imprimir log no console (quando não tem acesso ao adb)
+        if (kDebugMode) {
+          await OAuthDebugLogger.printLogToConsole();
         }
 
         return loginResponse;

--- a/lib/features/auth_google/screens/auth_google_login_screen.dart
+++ b/lib/features/auth_google/screens/auth_google_login_screen.dart
@@ -8,7 +8,10 @@ class AuthGoogleLoginScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CupertinoPageScaffold(
-      navigationBar: const CupertinoNavigationBar(middle: Text("Home")),
+      navigationBar: const CupertinoNavigationBar(
+        transitionBetweenRoutes: false,
+        middle: Text("Home"),
+      ),
       child: Center(
         child: Text(data ?? "Nenhum dado recebido no AuthGoogleLoginScreen!!"),
       ),

--- a/lib/features/chatbot/chat_screen.dart
+++ b/lib/features/chatbot/chat_screen.dart
@@ -58,6 +58,7 @@ class _ChatScreenState extends State<ChatScreen> {
       builder: (context, controller, child) {
         return CupertinoPageScaffold(
           navigationBar: const CupertinoNavigationBar(
+            transitionBetweenRoutes: false,
             middle: Text('AI Chat (MVC)'),
           ),
           child: SafeArea(

--- a/lib/features/chatbot/screens/test_main_chat_screen_code_2.dart
+++ b/lib/features/chatbot/screens/test_main_chat_screen_code_2.dart
@@ -149,6 +149,7 @@ class _ChatScreenState extends State<ChatScreen> {
   Widget build(BuildContext context) {
     return CupertinoPageScaffold(
       navigationBar: const CupertinoNavigationBar(
+        transitionBetweenRoutes: false,
         middle: Text('AI Chat'), // Title for the navigation bar
       ),
       backgroundColor:

--- a/lib/features/main_contents/profile/screens/main_content_profile_screen.dart
+++ b/lib/features/main_contents/profile/screens/main_content_profile_screen.dart
@@ -29,6 +29,7 @@ class _MainContentProfileScreenState extends State<MainContentProfileScreen> {
   Widget build(BuildContext context) {
     return CupertinoPageScaffold(
       navigationBar: const CupertinoNavigationBar(
+        transitionBetweenRoutes: false,
         middle: Text(">> Lista Contatos para Ambos <<"),
       ),
       child: SingleChildScrollView(

--- a/lib/features/main_contents/relation/screens/main_content_relation_screen.dart
+++ b/lib/features/main_contents/relation/screens/main_content_relation_screen.dart
@@ -30,6 +30,7 @@ class _MainContentRelationScreenState extends State<MainContentRelationScreen> {
   Widget build(BuildContext context) {
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
+        transitionBetweenRoutes: false,
         middle: const Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/features/main_contents/topic/screens/main_content_topic_screen.dart
+++ b/lib/features/main_contents/topic/screens/main_content_topic_screen.dart
@@ -92,6 +92,7 @@ class _MainContentTopicScreenState extends State<MainContentTopicScreen>
 
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
+        transitionBetweenRoutes: false,
         middle: const Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/features/main_contents/topic/screens/main_content_topic_screen_backup.dart
+++ b/lib/features/main_contents/topic/screens/main_content_topic_screen_backup.dart
@@ -90,6 +90,7 @@ class _MainContentTopicScreenState extends State<MainContentTopicScreen>
 
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
+        transitionBetweenRoutes: false,
         middle: const Text(">> Perfil de Consumidor - Default <<"),
         trailing: GestureDetector(
           onTap: () {

--- a/lib/features/user/screens/user_list_screen.dart
+++ b/lib/features/user/screens/user_list_screen.dart
@@ -43,6 +43,7 @@ class _UserListScreenState extends State<UserListScreen> {
 
           return CupertinoPageScaffold(
             navigationBar: CupertinoNavigationBar(
+              transitionBetweenRoutes: false,
               middle: Text(
                 AppLocalizations.of(context)!.userSimpleListViewTitle,
               ),

--- a/lib/util/oauth_debug_logger.dart
+++ b/lib/util/oauth_debug_logger.dart
@@ -1,0 +1,166 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:intl/intl.dart';
+
+/// 🐛 Debug Logger para OAuth Google
+/// 
+/// Salva dados JSON de autenticação Google em arquivo .log
+/// para fins de análise e estudo durante desenvolvimento.
+/// 
+/// **ATENÇÃO:** Este logger só funciona em modo DEBUG.
+/// Dados sensíveis NUNCA são salvos em produção.
+class OAuthDebugLogger {
+  /// Flag para ativar/desativar logging
+  /// 
+  /// ⚠️ Defina como `false` ao comitar código
+  static const bool isEnabled = true;
+
+  /// Nome do arquivo de log
+  static const String _logFileName = 'google_oauth_debug.log';
+
+  /// Formato de timestamp
+  static final DateFormat _timestampFormat = DateFormat('yyyy-MM-dd HH:mm:ss.SSS');
+
+  /// Salva dados do Google OAuth em arquivo .log
+  /// 
+  /// **Estrutura do Log:**
+  /// ```json
+  /// {
+  ///   "timestamp": "2026-02-15 14:30:45.123",
+  ///   "loginEvent": "GOOGLE_OAUTH_SUCCESS",
+  ///   "googleData": {
+  ///     "id": "...",
+  ///     "email": "...",
+  ///     "displayName": "...",
+  ///     "photoUrl": "...",
+  ///     "accessToken": "...",
+  ///     "idToken": "...",
+  ///     "scopes": [...]
+  ///   },
+  ///   "backendResponse": {
+  ///     "token": "...",
+  ///     "user": {...}
+  ///   }
+  /// }
+  /// ```
+  static Future<void> logOAuthData({
+    required Map<String, dynamic> googleData,
+    Map<String, dynamic>? backendResponse,
+    String? errorMessage,
+  }) async {
+    // 🚫 Apenas em modo DEBUG
+    if (!kDebugMode || !isEnabled) {
+      return;
+    }
+
+    try {
+      final file = await _getLogFile();
+      
+      // Estrutura do log
+      final logEntry = {
+        'timestamp': _timestampFormat.format(DateTime.now()),
+        'loginEvent': errorMessage == null ? 'GOOGLE_OAUTH_SUCCESS' : 'GOOGLE_OAUTH_ERROR',
+        if (errorMessage != null) 'error': errorMessage,
+        'googleData': googleData,
+        if (backendResponse != null) 'backendResponse': backendResponse,
+      };
+
+      // JSON formatado com indentação
+      const encoder = JsonEncoder.withIndent('  ');
+      final prettyJson = encoder.convert(logEntry);
+
+      // Sobrescreve o arquivo (sempre mantém apenas o último login)
+      await file.writeAsString(prettyJson);
+
+      debugPrint('📝 [OAuthDebugLogger] Log salvo em: ${file.path}');
+      debugPrint('📂 [OAuthDebugLogger] Acesse o arquivo via: Files > On My iPhone > Portugal Guide');
+    } catch (e) {
+      debugPrint('❌ [OAuthDebugLogger] Erro ao salvar log: $e');
+    }
+  }
+
+  /// Obtém referência ao arquivo de log
+  /// 
+  /// **Localização:**
+  /// - iOS: Documents/google_oauth_debug.log (visível no Files app)
+  /// - Android: Documents/google_oauth_debug.log (visível no File Manager)
+  static Future<File> _getLogFile() async {
+    final directory = await getApplicationDocumentsDirectory();
+    return File('${directory.path}/$_logFileName');
+  }
+
+  /// Lê o conteúdo atual do log (para debug no console)
+  static Future<String?> readLog() async {
+    if (!kDebugMode || !isEnabled) {
+      return null;
+    }
+
+    try {
+      final file = await _getLogFile();
+      if (await file.exists()) {
+        return await file.readAsString();
+      }
+      return null;
+    } catch (e) {
+      debugPrint('❌ [OAuthDebugLogger] Erro ao ler log: $e');
+      return null;
+    }
+  }
+
+  /// Deleta o arquivo de log (limpeza)
+  static Future<void> clearLog() async {
+    if (!kDebugMode) {
+      return;
+    }
+
+    try {
+      final file = await _getLogFile();
+      if (await file.exists()) {
+        await file.delete();
+        debugPrint('🗑️ [OAuthDebugLogger] Log deletado');
+      }
+    } catch (e) {
+      debugPrint('❌ [OAuthDebugLogger] Erro ao deletar log: $e');
+    }
+  }
+
+  /// Imprime caminho do arquivo de log no console
+  static Future<void> printLogPath() async {
+    if (!kDebugMode || !isEnabled) {
+      return;
+    }
+
+    try {
+      final file = await _getLogFile();
+      debugPrint('📂 [OAuthDebugLogger] Caminho do log: ${file.path}');
+      debugPrint('📂 [OAuthDebugLogger] Arquivo existe: ${await file.exists()}');
+    } catch (e) {
+      debugPrint('❌ [OAuthDebugLogger] Erro ao obter caminho: $e');
+    }
+  }
+
+  /// 🚀 HELPER: Imprime conteúdo completo do log no console
+  /// Útil quando não tem acesso ao adb (Android) ou não encontra o arquivo
+  static Future<void> printLogToConsole() async {
+    if (!kDebugMode || !isEnabled) {
+      return;
+    }
+
+    try {
+      final content = await readLog();
+      if (content != null) {
+        debugPrint('\n' + '=' * 80);
+        debugPrint('📜 [OAuthDebugLogger] CONTEÚDO DO LOG:');
+        debugPrint('=' * 80);
+        debugPrint(content);
+        debugPrint('=' * 80 + '\n');
+      } else {
+        debugPrint('⚠️ [OAuthDebugLogger] Log ainda não existe. Faça login com Google primeiro.');
+      }
+    } catch (e) {
+      debugPrint('❌ [OAuthDebugLogger] Erro ao ler log: $e');
+    }
+  }
+}


### PR DESCRIPTION
…g logging system

- Create OAuthDebugLogger utility to save OAuth JSON data to .log file for development analysis
- Implement YouTube User ID (without UC prefix) and Channel ID (with UC prefix) capture
- Add automatic User ID extraction by removing "UC" prefix from Channel ID
- Integrate YouTube Data API v3 channels?mine=true endpoint with multiple fallback methods
- Extend AuthGoogleUserData model with youtubeUserId, youtubeChannelId, and youtubeChannelTitle fields
- Update AuthGoogleOAuthRequest to send both YouTube IDs to backend
- Add comprehensive debug logging with automatic console printing for Android environments
- Fix Hero tag duplication across 10 navigation screens with transitionBetweenRoutes: false

Breaking changes: Backend must accept youtubeUserId and youtubeChannelId fields